### PR TITLE
remove setting last contact with leader on vote requests.

### DIFF
--- a/raft.go
+++ b/raft.go
@@ -1226,7 +1226,7 @@ func (r *Raft) requestVote(rpc RPC, req *RequestVoteRequest) {
 	}
 
 	resp.Granted = true
-	r.setLastContact()
+
 	return
 }
 


### PR DESCRIPTION
fixes #285, it also doesn't make any sense, having a candidate accepted by another node doesn't make it a leader.